### PR TITLE
Change base64 detection

### DIFF
--- a/greenwhisper
+++ b/greenwhisper
@@ -104,7 +104,7 @@ strings $1 | egrep -o "\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,6}\b" > ou
 printf '\n    [*] Extracting URL Encoded strings, piping to: "output/url_encoding"'
 strings $1 | egrep "(?!%22)[!@#$%^&*]" > output/url_encoding
 printf '\n    [*] Extracting Base64 encoded strings, piping to: "output/base64_strings"\n'
-strings $1 | egrep -o "^[-A-Za-z0-9+=]{1,50}|=[^=]|={3,}$" > output/base64_strings
+strings $1 | egrep -o "([A-Za-z0-9+/]{4})*([A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{2}==)" > output/base64_strings
 #########################################################
 # Print output directory to terminal:
 #########################################################


### PR DESCRIPTION
Update the regex for base64 strings to miss less potentially base64-encoded strings.

